### PR TITLE
Locked to the 1.x release train of BigAssFansAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
-    "BigAssFansAPI": ">=1.1.1"
+    "BigAssFansAPI": "~1.1.1"
   },
   "homepage": "https://github.com/sean9keenan/homebridge-bigAssFans"
 }


### PR DESCRIPTION
Allowing for some breaking changes in 2.x, while still being able to push patches if needed.