### PR TITLE
properly process occupancy value

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ function BigAssFanAccessory(log, config, existingAccessory) {
   }
 
   var occupancyGetWrapper = function(value) {
-    return (value ? Characteristic.OccupancyDetected.OCCUPANCY_DETECTED : Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED);
+    return (value === "OCCUPIED" ? Characteristic.OccupancyDetected.OCCUPANCY_DETECTED : Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED);
   }
 
   var lightMaxBrightness = this.myBigAss.light.max ? this.myBigAss.light.max : 16;


### PR DESCRIPTION
I found using this example program that the occupancy value being stored is not the same value that is passed to the `update` callback:

```javascript
var bigApi = require("BigAssFansAPI");

const fm = new bigApi.FanMaster(3);
fm.onFanConnection = function(fan) {
  console.log(fan.name, 'isOccupied pre-update', fan.sensor._isOccupied);
  fan.sensor.update('isOccupied', function(err, value) {
    console.log(fan.name, 'isOccupied update', fan.sensor._isOccupied, err, value);
  });
};
```

```
second bedroom isOccupied pre-update undefined
Living Room Fan isOccupied pre-update undefined
main bedroom isOccupied pre-update undefined
second bedroom isOccupied update true null OCCUPIED
Living Room Fan isOccupied update false null UNOCCUPIED
main bedroom isOccupied update false null UNOCCUPIED
```

This implies that either the `occupancyGetWrapper` function is not implemented correctly or the property `update` function needs to use the subProperty value, rather than the raw value:
https://github.com/sean9keenan/BigAssFansAPI/blob/3e8261577e0c76210638e9471af8387444c7e900/BigAssApi.js#L149-L150